### PR TITLE
Build py_project to install `install_requires` libraries

### DIFF
--- a/prepare-and-run-mypy.sh
+++ b/prepare-and-run-mypy.sh
@@ -72,4 +72,9 @@ fi
 
 $PY_EXE -m pip install $VERSIONS
 
+curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/ci-support.sh
+source ci-support.sh
+
+build_py_project
+
 ./run-mypy.sh


### PR DESCRIPTION
Should solve issues like: https://github.com/inducer/pytato/runs/2671439587?check_suite_focus=true, where the mypy CI failed because mypy couldn't find any library stub implementations for one of the dependency