### PR TITLE
Do not upload docs for PRs on Gitlab that are targeted towards main

### DIFF
--- a/ci-support.sh
+++ b/ci-support.sh
@@ -434,7 +434,8 @@ build_docs()
 
 maybe_upload_docs()
 {
-  if test -n "${DOC_UPLOAD_KEY}" && test "$CI_DEFAULT_BRANCH" && test "$CI_COMMIT_REF_NAME" = "$CI_DEFAULT_BRANCH"; then
+  if test -n "${DOC_UPLOAD_KEY}" && test "$CI_DEFAULT_BRANCH" && \
+      test "$CI_COMMIT_BRANCH"  && test "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH"; then
     cat > doc_upload_ssh_config <<END
 Host doc-upload
    User doc


### PR DESCRIPTION
Here is the latest doc build of loopy that includes docs from kernel callables:

![](https://i.imgur.com/SP9tSAm.png)