### PR TITLE
Avoid calling grep when no match is to be found

### DIFF
--- a/ci-support.sh
+++ b/ci-support.sh
@@ -124,8 +124,11 @@ pip_install_project()
     # Filter out any numpy requirements, install first. Otherwise some packages
     # might build against wrong version of numpy.
     # Context: https://github.com/numpy/numpy/issues/20709
-    grep -e "^numpy" "$REQUIREMENTS_TXT" > ci-support-numpy-req.txt
-    with_echo pip install -r ci-support-numpy-req.txt
+    if grep -q "^numpy" "$REQUIREMENTS_TXT"; then
+      echo "Installing numpy first to avoid numpy#20709."
+      grep -e "^numpy" "$REQUIREMENTS_TXT" > ci-support-numpy-req.txt
+      with_echo pip install -r ci-support-numpy-req.txt
+    fi
 
     with_echo pip install -r "$REQUIREMENTS_TXT"
   fi


### PR DESCRIPTION
GREP(1) returns '1' when no lines are matched.

Avoids CI failures as seen here: https://github.com/inducer/pytato/runs/4729023597?check_suite_focus=true.

Although note that those CIs failed with slightly unhelpful messages:
```sh
.
.
.
zlib                      1.2.11            h36c2ea0_1013    conda-forge
+++ rm -rf .miniforge3/envs/testing/x86_64-conda-linux-gnu/sysroot
Error: Process completed with exit code 1.
```
The real issue was the absolute next command in the script and that's been fixed here.

---
TODO:
- [X] Demonstrate a test run
  - See https://github.com/inducer/pytato/pull/239.