### PR TITLE
Don't fail when /proc/cpuinfo has no model name

### DIFF
--- a/ci-support.sh
+++ b/ci-support.sh
@@ -76,7 +76,7 @@ print_status_message()
   echo "git revision: $(git rev-parse --short HEAD)"
   echo "git status:"
   git status -s
-  test -f /proc/cpuinfo && ( grep 'model name' /proc/cpuinfo | head -n 1)
+  test -f /proc/cpuinfo && ((grep 'model name' /proc/cpuinfo | head -n 1) || true)
   echo "-----------------------------------------------"
 }
 


### PR DESCRIPTION
e.g., docker containers at least on macOS only have:

```
| + cat /proc/cpuinfo
| processor	: 0
| BogoMIPS	: 48.00
| Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint
| CPU implementer	: 0x00
| CPU architecture: 8
| CPU variant	: 0x0
| CPU part	: 0x000
| CPU revision	: 0
|
| processor	: 1
| BogoMIPS	: 48.00
| Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint
| CPU implementer	: 0x00
| CPU architecture: 8
| CPU variant	: 0x0
| CPU part	: 0x000
| CPU revision	: 0
```