### PR TITLE
Fix conditional for disable-editable-pip-install

### DIFF
--- a/ci-support.sh
+++ b/ci-support.sh
@@ -259,14 +259,10 @@ pip_install_project()
   # Append --editable to PROJECT_INSTALL_FLAGS, if not there already and if not
   # disabled.
   if ! test -f setup.cfg || ! grep -q disable-editable-pip-install setup.cfg; then
-    if [[ ! $PROJECT_INSTALL_FLAGS =~ (^|[[:space:]]*)(--editable|-e)[[:space:]]*$ ]]; then
-        PROJECT_INSTALL_FLAGS="$PROJECT_INSTALL_FLAGS --editable"
-    fi
-  fi
-
-  if ! test -f pyproject.toml || ! grep -q disable-editable-pip-install pyproject.toml; then
-    if [[ ! $PROJECT_INSTALL_FLAGS =~ (^|[[:space:]]*)(--editable|-e)[[:space:]]*$ ]]; then
-        PROJECT_INSTALL_FLAGS="$PROJECT_INSTALL_FLAGS --editable"
+    if ! test -f pyproject.toml || ! tomlsh pyproject.toml has-key tool.inducer-ci-support.disable-editable-pip-install; then
+      if [[ ! $PROJECT_INSTALL_FLAGS =~ (^|[[:space:]]*)(--editable|-e)[[:space:]]*$ ]]; then
+          PROJECT_INSTALL_FLAGS="$PROJECT_INSTALL_FLAGS --editable"
+      fi
     fi
   fi
 


### PR DESCRIPTION
Was this correct before? It seems to make pyopencl fail after I removed `setup.cfg`.