### PR TITLE
fix path for rewrite_pyopencl_test

### DIFF
--- a/ci-support.sh
+++ b/ci-support.sh
@@ -58,7 +58,7 @@ fi
 
 rewrite_pyopencl_test()
 {
-  if python -c 'import pyopencl as cl; import pyopencl.characterize as c; v = [c.get_pocl_version(p) for p in cl.get_platforms()]; v, = [i for i in v if i];  import sys; sys.exit(not v >= (4,0))'; then
+  if (cd ..; $PY_EXE -c 'import pyopencl as cl; import pyopencl.characterize as c; v = [c.get_pocl_version(p) for p in cl.get_platforms()]; v, = [i for i in v if i];  import sys; sys.exit(not v >= (4,0))'); then
     export PYOPENCL_TEST
     PYOPENCL_TEST="$(echo "${PYOPENCL_TEST}" | sed s/pthread/cpu/ )"
   fi


### PR DESCRIPTION
Avoids errors like 
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/pyopencl/pyopencl/pyopencl/__init__.py", line 29, in <module>
    import pyopencl.cltypes
  File "/home/runner/work/pyopencl/pyopencl/pyopencl/cltypes.py", line 25, in <module>
    from pyopencl.tools import get_or_register_dtype
  File "/home/runner/work/pyopencl/pyopencl/pyopencl/tools.py", line 139, in <module>
    from pyopencl._cl import bitlog2, get_cl_header_version  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pyopencl._cl'
```
in pyopencl CI.

(see e.g. https://github.com/inducer/pyopencl/actions/runs/10635887637/job/29486497845)