### PR TITLE
Allow underscores in requirement URL

### DIFF
--- a/transfer-requirements-git-urls
+++ b/transfer-requirements-git-urls
@@ -6,7 +6,7 @@ import re
 
 
 vcs_url_re = re.compile(
-        r"(git\+[a-z]+://[-a-zA-Z0-9./]+)"
+        r"(git\+[a-z]+://[-_a-zA-Z0-9./]+)"
         "((?:@[-_a-zA-Z0-9]+)?)"
         r"\#egg=([-a-zA-Z0-9_.]+)"
         )


### PR DESCRIPTION
I think this is causing the CI in inducer/meshmode#477 to grab the wrong gmsh_interop branch.